### PR TITLE
Add SMB reconnect support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,10 @@ WORKDIR /usr/src/app
 
 # Copy the requirements file and install dependencies
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends cifs-utils \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir -r requirements.txt
 
 # Copy the rest of the application code to the container
 COPY file_mover ./file_mover

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ docker stop <container-id-or-name>
 - **Source Folder**: The directory to be monitored for new files.
 - **Destination Folder**: The directory where files will be moved, preserving the directory structure.
 - The script also respects the `SOURCE_FOLDER` and `DEST_FOLDER` environment variables. If set, these values override command-line arguments and defaults.
+- To use an SMB share directly, set `DEST_SMB` to the share path (e.g. `//server/share`).
+  Optional `SMB_USERNAME` and `SMB_PASSWORD` variables can provide credentials.
+  The application mounts the share at `/destination_folder` and will attempt to
+  reconnect automatically if the mount is lost.
 
 ## Example
 

--- a/file_mover/__init__.py
+++ b/file_mover/__init__.py
@@ -1,5 +1,6 @@
 """File mover package."""
 
 from .handler import FileMoverHandler, Observer  # noqa: F401
+from .smb_utils import start_smb_monitor  # noqa: F401
 
-__all__ = ["FileMoverHandler", "Observer"]
+__all__ = ["FileMoverHandler", "Observer", "start_smb_monitor"]

--- a/file_mover/__main__.py
+++ b/file_mover/__main__.py
@@ -4,6 +4,7 @@ import sys
 import time
 
 from .handler import FileMoverHandler, Observer
+from .smb_utils import start_smb_monitor
 
 def main() -> None:
     logging.basicConfig(
@@ -24,6 +25,15 @@ def main() -> None:
         destination_folder = sys.argv[2]
     else:
         destination_folder = "/destination_folder"
+
+    smb_share = os.environ.get("DEST_SMB")
+    if smb_share:
+        start_smb_monitor(
+            smb_share,
+            destination_folder,
+            os.environ.get("SMB_USERNAME"),
+            os.environ.get("SMB_PASSWORD"),
+        )
 
     event_handler = FileMoverHandler(source_folder, destination_folder)
 

--- a/file_mover/smb_utils.py
+++ b/file_mover/smb_utils.py
@@ -1,0 +1,50 @@
+import logging
+import os
+import subprocess
+import threading
+import time
+
+
+def _mount(share: str, mount_point: str, username: str | None = None, password: str | None = None) -> None:
+    """Mount the SMB share using mount.cifs."""
+    opts = []
+    if username:
+        opts.append(f"username={username}")
+    if password:
+        opts.append(f"password={password}")
+    cmd = ["mount", "-t", "cifs", share, mount_point]
+    if opts:
+        cmd += ["-o", ",".join(opts)]
+    logging.info("Running %s", " ".join(cmd))
+    subprocess.run(cmd, check=True)
+
+
+def ensure_mounted(share: str, mount_point: str, username: str | None = None, password: str | None = None) -> None:
+    """Ensure the SMB share is mounted."""
+    if not os.path.ismount(mount_point):
+        try:
+            os.makedirs(mount_point, exist_ok=True)
+            _mount(share, mount_point, username, password)
+            logging.info("Mounted SMB share %s at %s", share, mount_point)
+        except Exception as exc:  # pragma: no cover - mount failures not tested
+            logging.error("Failed to mount SMB share: %s", exc)
+
+
+def _monitor(share: str, mount_point: str, username: str | None = None, password: str | None = None, interval: int = 30) -> None:
+    """Periodically check if the mount is active and remount if needed."""
+    while True:
+        if not os.path.ismount(mount_point):
+            logging.warning("SMB mount lost, attempting to remount...")
+            try:
+                _mount(share, mount_point, username, password)
+                logging.info("Remounted SMB share %s", share)
+            except Exception as exc:  # pragma: no cover - mount failures not tested
+                logging.error("Remount failed: %s", exc)
+        time.sleep(interval)
+
+
+def start_smb_monitor(share: str, mount_point: str, username: str | None = None, password: str | None = None, interval: int = 30) -> None:
+    """Start a background thread that ensures the SMB share stays mounted."""
+    ensure_mounted(share, mount_point, username, password)
+    thread = threading.Thread(target=_monitor, args=(share, mount_point, username, password, interval), daemon=True)
+    thread.start()

--- a/tests/test_smb_utils.py
+++ b/tests/test_smb_utils.py
@@ -1,0 +1,65 @@
+import pytest
+from file_mover import smb_utils
+
+
+class DummyThread:
+    def __init__(self, target, args, daemon=False):
+        self.target = target
+        self.args = args
+        self.daemon = daemon
+        self.started = False
+
+    def start(self):
+        self.started = True
+
+def test_ensure_mounted_calls_mount(monkeypatch, tmp_path):
+    calls = []
+    monkeypatch.setattr(smb_utils.os.path, "ismount", lambda p: False)
+    monkeypatch.setattr(smb_utils.os, "makedirs", lambda p, exist_ok: calls.append("makedirs"))
+    monkeypatch.setattr(smb_utils, "_mount", lambda *a, **k: calls.append((a, k)))
+
+    smb_utils.ensure_mounted("//share", str(tmp_path))
+
+    assert calls and calls[0] == "makedirs"
+    assert calls[1][0][0] == "//share"
+
+
+def test_monitor_remounts_when_lost(monkeypatch):
+    events = {"mount_called": False, "sleep_called": 0}
+
+    def fake_ismount(path):
+        return False
+
+    def fake_mount(*a, **k):
+        events["mount_called"] = True
+
+    def fake_sleep(i):
+        events["sleep_called"] += 1
+        raise StopIteration
+
+    monkeypatch.setattr(smb_utils.os.path, "ismount", fake_ismount)
+    monkeypatch.setattr(smb_utils, "_mount", fake_mount)
+    monkeypatch.setattr(smb_utils.time, "sleep", fake_sleep)
+
+    with pytest.raises(StopIteration):
+        smb_utils._monitor("//share", "/mnt", interval=0)
+
+    assert events["mount_called"]
+    assert events["sleep_called"] == 1
+
+
+def test_start_smb_monitor_starts_thread(monkeypatch, tmp_path):
+    called = {}
+
+    def fake_thread(target, args, daemon=False):
+        called["target"] = target
+        called["args"] = args
+        return DummyThread(target, args, daemon)
+
+    monkeypatch.setattr(smb_utils, "ensure_mounted", lambda *a, **k: called.setdefault("ensure", True))
+    monkeypatch.setattr(smb_utils.threading, "Thread", fake_thread)
+
+    smb_utils.start_smb_monitor("//share", str(tmp_path))
+
+    assert called.get("ensure")
+    assert called["target"] == smb_utils._monitor


### PR DESCRIPTION
## Summary
- install `cifs-utils` so SMB shares can be mounted
- add `smb_utils` helper to keep an SMB share mounted
- expose `start_smb_monitor`
- mount SMB share when `DEST_SMB` is set and reconnect if lost
- document SMB environment variables
- test SMB mounting and reconnection logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b1c06d3b883219a3a0fa81aa898f6