### PR TITLE
Exit container when watchdog observer thread crashes

### DIFF
--- a/file_mover/__main__.py
+++ b/file_mover/__main__.py
@@ -34,6 +34,12 @@ def main() -> None:
     try:
         while True:
             time.sleep(1)
+            if not observer.is_alive():
+                logging.error(
+                    "Observer thread died unexpectedly, exiting for restart..."
+                )
+                observer.stop()
+                sys.exit(1)
     except KeyboardInterrupt:
         observer.stop()
         logging.info("Stopping observer...")

--- a/file_mover/handler.py
+++ b/file_mover/handler.py
@@ -10,14 +10,20 @@ except ImportError:  # pragma: no cover - fallback for environments without watc
         pass
 
     class Observer:  # type: ignore
+        def __init__(self):
+            self._alive = False
+
         def schedule(self, *_, **__):
             pass
 
         def start(self):
-            pass
+            self._alive = True
 
         def stop(self):
-            pass
+            self._alive = False
+
+        def is_alive(self):
+            return self._alive
 
         def join(self):
             pass


### PR DESCRIPTION
## Summary
- update `file_mover/__main__.py` to check `observer.is_alive()` in the main loop
- log an error and terminate with `sys.exit(1)` when the observer thread dies so Docker `restart: always` can restart the container
- extend the fallback `Observer` shim in `file_mover/handler.py` with lifecycle state and an `is_alive()` method to match the production observer interface

## Validation
- `pytest -q`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699de58fc8e483218576031b7733112f)